### PR TITLE
Encoding support for game status

### DIFF
--- a/PlayStationDiscord/DiscordRPC.cs
+++ b/PlayStationDiscord/DiscordRPC.cs
@@ -45,7 +45,7 @@ namespace PlayStationDiscord
 		[System.Serializable, StructLayout(LayoutKind.Sequential)]
 		public struct RichPresence
 		{
-            public IntPtr state; /* max 128 bytes */
+            		public IntPtr state; /* max 128 bytes */
 			public IntPtr details; /* max 128 bytes */
 			public long startTimestamp;
 			public long endTimestamp;

--- a/PlayStationDiscord/DiscordRPC.cs
+++ b/PlayStationDiscord/DiscordRPC.cs
@@ -45,7 +45,7 @@ namespace PlayStationDiscord
 		[System.Serializable, StructLayout(LayoutKind.Sequential)]
 		public struct RichPresence
 		{
-			public string state; /* max 128 bytes */
+            public IntPtr state; /* max 128 bytes */
 			public IntPtr details; /* max 128 bytes */
 			public long startTimestamp;
 			public long endTimestamp;


### PR DESCRIPTION
Howdy!  

Currently, when you're playing in any game that has status in non-latin language (for example, Russian) you will see a bunch of question marks in Discord. I've fixed that issue with the same wat as game name was fixed and moved converting string to pointer in a separate method in order to remove duplication

*Before*:
![image](https://user-images.githubusercontent.com/7874195/47616700-61491680-dad1-11e8-82a7-855b31794a1b.png)
*After*:
![image](https://user-images.githubusercontent.com/7874195/47616690-4b3b5600-dad1-11e8-94bf-ca4973971601.png)
