### PR TITLE
Fix some enable/disable presence button issues

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -520,7 +520,12 @@ ipcMain.on('toggle-presence', () => {
 
 	if (!newValue)
 	{
+		appEvent.emit('stop-rich-presence');
 		discordController.stop();
+	}
+	else
+	{
+		appEvent.emit('start-rich-presence');
 	}
 });
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -2,6 +2,8 @@ const { ipcRenderer } = require('electron');
 const fs = require('fs');
 const path = require('path');
 const log = require('electron-log');
+const _store = require('electron-store');
+const store = new _store();
 
 const togglePresence = document.getElementById('togglePresence');
 const signOut = document.getElementById('signOut');
@@ -110,3 +112,12 @@ togglePresence.addEventListener('click', () => {
 signOut.addEventListener('click', () => {
 	ipcRenderer.send('signout');
 });
+
+window.onload = () => {
+	// Update initial state of rich presence button
+	if (!store.get('presenceEnabled', true))
+	{
+		togglePresence.classList.remove('red');
+		togglePresence.innerHTML = 'Enable Rich Presence';
+	}
+};


### PR DESCRIPTION
This PR hooks up the presence button to the rest of the enable/disable rich presence logic. This should prevent unnecessary PSN api requests, and fix issues with rich presence not actually re-enabling after pressing the button.

This also updates the button to show the correct text between program restarts