### PR TITLE
Introduce dockerfile for building and running the app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:10.16.2-slim
+
+RUN apt-get update \
+ && apt-get --no-install-recommends -y install python-minimal python-dev make g++ libglib2.0-0 libnss3 libgtk-3-0 libxtst6 libxss1 libasound2 bzip2 \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/scr/app
+COPY . /usr/scr/app
+
+RUN npm config set scripts-prepend-node-path true
+RUN yarn install --pure-lockfile
+
+CMD yarn start

--- a/playstation-discord-docker.sh
+++ b/playstation-discord-docker.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -o errexit
+# this script expects the docker image to be tagged 'playstation-discord' during the build like this:
+# docker build -t playstation-discord .
+
+docker rm playstation-discord || true
+exec docker run -it \
+  -v /tmp/.X11-unix:/tmp/.X11-unix \
+  -e DISPLAY=$DISPLAY \
+  -v $HOME/.Xauthority:/root/.Xauthority \
+  --network="host" \
+  -v ${XDG_RUNTIME_DIR}/discord-ipc-0:/tmp/discord-ipc-0 \
+  --name playstation-discord \
+  playstation-discord


### PR DESCRIPTION
* also adds a shell script for running the container with volumes and env variables

As noted in the readme, there are no Linux builds provided. I'm not a fan of installing node and/or letting npm pollute my computer, so I produced this docker image to build and run the app. This makes the actual requirements for running the app very clear, and has the additional benefit that it should be portable between various Linux distros, at least the ones that can run both docker and the native Discord client.

It might be worth adding a line in the readme that the native Discord client is required for this app, and the Rich Presence API in general, i.e. it cannot connect to the Discord web interface.