### PR TITLE
Added toggle presence button in tray context menu 

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -164,6 +164,10 @@ function spawnMainWindow() : void
 			click:  () => mainWindow.show()
 		},
 		{
+			label: 'Toggle Presence',
+			click:  () => ipcMain.emit('toggle-presence')
+		},
+		{
 			label: 'Quit',
 			click:  () => {
 				mainWindow.destroy();


### PR DESCRIPTION
Currently works as intended for easier toggling without having to wait for the window to pop up when hidden. However, the enable/disable button on the main screen doesn't change correctly when changed from the context menu, and I've been unable to find a decent way to change the button's class when not visible to fix this. Because the button sends `toggle-presence` to the IPC handler regardless of its state, this is purely a visual issue and has no impact on the button's functionality to the best of my knowledge.